### PR TITLE
ItemとCategoryの紐づけ

### DIFF
--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -1,5 +1,6 @@
 class Member::ItemsController < Member::ApplicationController
   before_action :set_item, only: %i[show edit update destroy]
+  before_action :set_categories, only: %i[new edit]
 
   # GET /items
   def index
@@ -52,8 +53,12 @@ class Member::ItemsController < Member::ApplicationController
       @item = Item.find(params[:id])
     end
 
+    def set_categories
+      @categories = Category.all
+    end
+
     # Only allow a trusted parameter "white list" through.
     def item_params
-      params.require(:item).permit(:name, :description, :condition, :price, :available)
+      params.require(:item).permit(:name, :description, :condition, :price, :available, category_ids: [])
     end
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,3 +1,6 @@
 class Category < ApplicationRecord
   validates :name, presence: true
+
+  has_many :item_categories, dependent: :destroy
+  has_many :items, through: :item_categories
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,6 +1,8 @@
 class Item < ApplicationRecord
   belongs_to :user
   has_many :deals
+  has_many :item_categories, dependent: :destroy
+  has_many :categories, through: :item_categories
 
   validates :name, presence: true
   validates :price, presence: true

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -1,0 +1,4 @@
+class ItemCategory < ApplicationRecord
+  belongs_to :item
+  belongs_to :category
+end

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -1,4 +1,7 @@
 class ItemCategory < ApplicationRecord
   belongs_to :item
   belongs_to :category
+
+  validates :item_id, presence: true
+  validates :category_id, presence: true
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,4 +10,7 @@ class User < ApplicationRecord
 
   has_many :borrowing_deals, foreign_key: 'borrower_id', class_name: 'Deal', dependent: :destroy
   has_many :lenders, through: :borrowing_deals, source: :lender
+
+  has_many :item_categories, dependent: :destroy
+  has_many :items, through: :item_categories
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,4 @@ class User < ApplicationRecord
 
   has_many :borrowing_deals, foreign_key: 'borrower_id', class_name: 'Deal', dependent: :destroy
   has_many :lenders, through: :borrowing_deals, source: :lender
-
-  has_many :item_categories, dependent: :destroy
-  has_many :items, through: :item_categories
 end

--- a/app/views/items/index.html.slim
+++ b/app/views/items/index.html.slim
@@ -1,5 +1,3 @@
-p#notice
-  = notice
 h1
   | Items
 table
@@ -9,6 +7,8 @@ table
         | User
       th
         | Name
+      th
+        | Category
       th
         | Description
       th
@@ -25,6 +25,10 @@ table
           = item.user.name
         td
           = item.name
+        td
+          - item.categories.each do |category|
+            |  •
+            =category.name
         td
           = item.description
         td

--- a/app/views/items/show.html.slim
+++ b/app/views/items/show.html.slim
@@ -1,5 +1,3 @@
-p#notice
-  = notice
 p
   strong
     | User:
@@ -8,6 +6,12 @@ p
   strong
     | Name:
   = @item.name
+p
+  strong
+    | Category:
+  - @item.categories.each do |category|
+    |  •
+    = category.name
 p
   strong
     | Description:

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -12,6 +12,9 @@
     = form.label :name
     = form.text_field :name
   .field
+    = form.collection_check_boxes :category_ids, @categories, :id, :name do |b|
+      = b.label { b.check_box + b.text }
+  .field
     = form.label :description
     = form.text_area :description
   .field

--- a/app/views/member/items/index.html.slim
+++ b/app/views/member/items/index.html.slim
@@ -8,6 +8,8 @@ table
       th
         | Name
       th
+        | Category
+      th
         | Description
       th
         | Condition
@@ -23,6 +25,10 @@ table
           = item.user.name
         td
           = item.name
+        td
+          - item.categories.each do |category|
+            |  •
+            =category.name
         td
           = item.description
         td

--- a/app/views/member/items/show.html.slim
+++ b/app/views/member/items/show.html.slim
@@ -8,6 +8,12 @@ p
   = @item.name
 p
   strong
+    | Category:
+  - @item.categories.each do |category|
+    |  •
+    = category.name
+p
+  strong
     | Description:
   = @item.description
 p

--- a/db/migrate/20190123135235_create_item_categories.rb
+++ b/db/migrate/20190123135235_create_item_categories.rb
@@ -1,0 +1,10 @@
+class CreateItemCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_categories do |t|
+      t.references :item, foreign_key: true
+      t.references :category, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 2019_01_21_142341) do
+ActiveRecord::Schema.define(version: 2019_01_23_135235) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -32,6 +31,15 @@ ActiveRecord::Schema.define(version: 2019_01_21_142341) do
     t.index ["borrower_id"], name: "index_deals_on_borrower_id"
     t.index ["item_id"], name: "index_deals_on_item_id"
     t.index ["lender_id"], name: "index_deals_on_lender_id"
+  end
+
+  create_table "item_categories", force: :cascade do |t|
+    t.bigint "item_id"
+    t.bigint "category_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["category_id"], name: "index_item_categories_on_category_id"
+    t.index ["item_id"], name: "index_item_categories_on_item_id"
   end
 
   create_table "items", force: :cascade do |t|
@@ -62,5 +70,7 @@ ActiveRecord::Schema.define(version: 2019_01_21_142341) do
   add_foreign_key "deals", "items"
   add_foreign_key "deals", "users", column: "borrower_id"
   add_foreign_key "deals", "users", column: "lender_id"
+  add_foreign_key "item_categories", "categories"
+  add_foreign_key "item_categories", "items"
   add_foreign_key "items", "users"
 end


### PR DESCRIPTION
## 変更の概要
* ItemとCategoryを多対多の関係にした(リレーションの設定及び中間テーブルを作成する)
* Itemの作成/更新時に紐付けるCategoryを複数選択できるようにした

参考url: https://qiita.com/shunn_93/items/17817c8a48915bf514ff
## 備考
リレーションの作成、Item作成時のチェックボックス、カテゴリー表示のためViewの変更まで終わっています。
ただし、member直下とviews直下でItemのViewが2種類あり、共通部分をパーシャルにまとめようと思っています。

一旦基本的な動作にかかわる部分は出来ましたのでご確認をお願いします。

## 追記　※1月25日
viewの重複部分をパーシャルで共通化しましたのでご確認お願いします。

### itemsビューの役割
* ネームスペースなしitems　-　全ユーザーが登録したアイテム
* member/items　-　自分が登録したアイテム

### itemsビューを共通化した部分
member/items/index.html.silim
items/index.html.silim　
→　`shared/_index_items.html.slim`

member/items/show.html.silim
items/show.html.silim
→　`shared/_show_items.html.slim`