### PR TITLE
Deal機能の実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,8 @@ gem 'uglifier', '>= 1.3.0'
 
 # for auth
 gem 'devise'
+# i18n for enum
+gem 'enum_help'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
       railties (>= 4.1.0, < 6.0)
       responders
       warden (~> 1.2.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
     ffi (1.10.0)
@@ -196,6 +198,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug
   devise
+  enum_help
   html2slim
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)

--- a/app/controllers/member/deals_controller.rb
+++ b/app/controllers/member/deals_controller.rb
@@ -14,18 +14,18 @@ class Member::DealsController < Member::ApplicationController
 
   # GET /deals/new
   def new
-    @deal = @item.deals.new(
-      lender_id: @item.user_id, borrower_id: current_user.id, unit_price: @item.price
-    )
+    @deal = @item.create_item_deals(current_user)
   end
 
   # GET /deals/1/edit
   def edit
+    redirect_to [:member, @deal], notice: '権限がありません。' if @deal.borrower?(current_user)
   end
 
   # POST /deals
   def create
     @deal = @item.deals.new(deal_params)
+    @deal.status = 'submitted'
 
     if @deal.borrower?(current_user) && @deal.save
       redirect_to [:member, @deal], notice: 'Deal was successfully created.'
@@ -61,6 +61,6 @@ class Member::DealsController < Member::ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def deal_params
-      params.require(:deal).permit(:item_id, :lender_id, :borrower_id, :unit_price)
+      params.require(:deal).permit(:item_id, :lender_id, :borrower_id, :unit_price, :status)
     end
 end

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -3,7 +3,7 @@ class Member::ItemsController < Member::ApplicationController
 
   # GET /items
   def index
-    @items = Item.all
+    @items = Item.where(user_id: current_user)
   end
 
   # GET /items/1
@@ -13,12 +13,10 @@ class Member::ItemsController < Member::ApplicationController
   # GET /items/new
   def new
     @item = Item.new
-    @categories = Category.all
   end
 
   # GET /items/1/edit
   def edit
-    @categories = Category.all
   end
 
   # POST /items

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -17,6 +17,7 @@ class Member::ItemsController < Member::ApplicationController
 
   # GET /items/1/edit
   def edit
+    redirect_to member_item_deals_path(@item), notice: ' 進行中の取引があります。' if @item.deals_in_progress?
   end
 
   # POST /items

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -1,6 +1,5 @@
 class Member::ItemsController < Member::ApplicationController
   before_action :set_item, only: %i[show edit update destroy]
-  before_action :set_categories, only: %i[new edit]
 
   # GET /items
   def index
@@ -14,10 +13,12 @@ class Member::ItemsController < Member::ApplicationController
   # GET /items/new
   def new
     @item = Item.new
+    @categories = Category.all
   end
 
   # GET /items/1/edit
   def edit
+    @categories = Category.all
   end
 
   # POST /items
@@ -51,10 +52,6 @@ class Member::ItemsController < Member::ApplicationController
     # Use callbacks to share common setup or constraints between actions.
     def set_item
       @item = Item.find(params[:id])
-    end
-
-    def set_categories
-      @categories = Category.all
     end
 
     # Only allow a trusted parameter "white list" through.

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -3,10 +3,16 @@ class Deal < ApplicationRecord
   belongs_to :lender, class_name: "User"
   belongs_to :borrower, class_name: "User"
 
+  enum status: { submitted: 0, approved: 1, delivered: 2, return: 3, rejected: 4, cancelled: 5 }
+
   validates :item_id, presence: true
   validates :lender_id, presence: true
   validates :borrower_id, presence: true
   validates :unit_price, presence: true
+  validates :status, null: false,
+    inclusion: { in: [
+      'submitted', 'approved', 'delivered', 'return', 'rejected', 'cancelled'
+      ] }
 
   def borrower?(current_user)
     borrower_id == current_user.id

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -25,4 +25,8 @@ class Item < ApplicationRecord
       unit_price: price,
     )
   end
+
+  def deals_in_progress?
+    deals.where(status: 0..2).present?
+  end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,4 +17,12 @@ class Item < ApplicationRecord
   def owner?(current_user)
     user_id == current_user.id
   end
+
+  def create_item_deals(current_user)
+    deals.new(
+      lender_id: user_id,
+      borrower_id: current_user.id,
+      unit_price: price,
+    )
+  end
 end

--- a/app/models/item_category.rb
+++ b/app/models/item_category.rb
@@ -1,7 +1,4 @@
 class ItemCategory < ApplicationRecord
   belongs_to :item
   belongs_to :category
-
-  validates :item_id, presence: true
-  validates :category_id, presence: true
 end

--- a/app/views/categories/edit.html.slim
+++ b/app/views/categories/edit.html.slim
@@ -1,6 +1,6 @@
 h1 Editing category
 
-== render 'form', category: @category
+= render 'form', category: @category
 
 => link_to 'Show', @category
 '|

--- a/app/views/categories/show.html.slim
+++ b/app/views/categories/show.html.slim
@@ -1,5 +1,3 @@
-p#notice = notice
-
 p
   strong Name:
   = @category.name

--- a/app/views/member/deals/_form.html.slim
+++ b/app/views/member/deals/_form.html.slim
@@ -2,7 +2,7 @@
   - if deal.errors.any?
     #error_explanation
       h2
-        = pluralize(user.errors.count, "error")
+        = pluralize(deal.errors.count, "error")
         |  prohibited this deal from being saved:
       ul
         - deal.errors.full_messages.each do |message|
@@ -21,6 +21,9 @@
     = form.label :unit_price
     = deal.unit_price
     = form.hidden_field :unit_price
-
+  - if !deal.new_record?
+    .field
+      = form.label :status
+      = form.select :status, Deal.statuses_i18n.keys.map { |k| [Deal.statuses_i18n[k], k]}
   .actions
     = form.submit

--- a/app/views/member/deals/index.html.slim
+++ b/app/views/member/deals/index.html.slim
@@ -8,6 +8,8 @@ table
       th Lender
       th Borrower
       th Unit price
+      th Status
+      th
       th
       th
       th
@@ -19,10 +21,11 @@ table
         td = lender_deal.lender.name
         td = lender_deal.borrower.name
         td = lender_deal.unit_price
+        td = lender_deal.status_i18n
         td = link_to 'Show', member_deal_path(lender_deal)
         td = link_to 'Edit', edit_member_deal_path(lender_deal)
-        td = link_to 'Destroy', member_deal_path(lender_deal),
-          data: { confirm: 'Are you sure?' }, method: :delete
+        td = button_to '承認', member_deal_path(lender_deal, params: { deal: { status: 'approved'} }), method: :patch
+        td = button_to '非承認', member_deal_path(lender_deal, params: { deal: { status: 'rejected'} }), method: :patch
 
 h2 borrower_deals
 table
@@ -32,6 +35,7 @@ table
       th Lender
       th Borrower
       th Unit price
+      th Status
       th
       th
       th
@@ -43,6 +47,7 @@ table
         td = borrower_deal.lender.name
         td = borrower_deal.borrower.name
         td = borrower_deal.unit_price
+        td = borrower_deal.status_i18n
         td = link_to 'Show', member_deal_path(borrower_deal)
         td = link_to 'Edit', edit_member_deal_path(borrower_deal)
         td = link_to 'Destroy', member_deal_path(borrower_deal),

--- a/app/views/member/deals/show.html.slim
+++ b/app/views/member/deals/show.html.slim
@@ -10,6 +10,9 @@ p
 p
   strong Unit price:
   = @deal.unit_price
+p
+  strong Status:
+  = @deal.status_i18n
 
 => link_to 'Edit', edit_member_deal_path(@deal)
 '|

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -12,7 +12,7 @@
     = form.label :name
     = form.text_field :name
   .field
-    = form.collection_check_boxes :category_ids, @categories, :id, :name do |b|
+    = form.collection_check_boxes :category_ids, @categories, :id, :name, include_hidden: false do |b|
       = b.label { b.check_box + b.text }
   .field
     = form.label :description

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -12,7 +12,7 @@
     = form.label :name
     = form.text_field :name
   .field
-    = form.collection_check_boxes :category_ids, @categories, :id, :name, include_hidden: false do |b|
+    = form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |b|
       = b.label { b.check_box + b.text }
   .field
     = form.label :description

--- a/config/application.rb
+++ b/config/application.rb
@@ -29,5 +29,9 @@ module SharingApp
 
     # Don't generate system test files.
     config.generators.system_tests = nil
+    # language to japanese
+    config.i18n.default_locale = :ja
+    # localeファイルへパスを通す
+    config.i18n.load_path += Dir[Rails.root.join('config', 'locales', '**', '*.{rb,yml}').to_s]
   end
 end

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,216 @@
+---
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  enums:
+    deal:
+      status:
+        submitted: 承認待ち
+        approved: 承認済み
+        delivered: 引き渡し
+        return: 返却
+        rejected: 非承認
+        cancelled: キャンセル
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+          pb: PB
+          eb: EB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -1,0 +1,36 @@
+ja:
+  activerecord:
+    models:
+      user: ユーザー
+      item: アイテム
+      deal: 取引
+      category: カテゴリ
+    attributes:
+      user:
+        id: ID
+        name: 名前
+        email: メールアドレス
+        password: パスワード
+        password_confirmation: パスワード（確認）
+        created_at: 登録日時
+        updated_at: 更新日時
+      item:
+        name: アイテム名
+        description: 詳しい説明
+        condition: 状態
+        price: 日当り単価
+        available: 貸出可否
+        created_at: 登録日時
+        updated_at: 更新日時
+      deal:
+        unit_price: 日当り単価
+        item: アイテム
+        lender: 貸し手
+        borrower: 借り手
+        status: ステータス
+        created_at: 登録日時
+        updated_at: 更新日時
+      category:
+        name: カテゴリ名
+        created_at: 登録日時
+        updated_at: 更新日時

--- a/db/migrate/20190126053113_add_status_to_deals.rb
+++ b/db/migrate/20190126053113_add_status_to_deals.rb
@@ -1,0 +1,5 @@
+class AddStatusToDeals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :deals, :status, :integer, default: 0, null:false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_23_135235) do
+ActiveRecord::Schema.define(version: 2019_01_26_053113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2019_01_23_135235) do
     t.string "unit_price", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "status", default: 0, null: false
     t.index ["borrower_id"], name: "index_deals_on_borrower_id"
     t.index ["item_id"], name: "index_deals_on_item_id"
     t.index ["lender_id"], name: "index_deals_on_lender_id"


### PR DESCRIPTION
## 変更の概要
* Dealの進行状況を保持するstatusカラムを追加
* Deal一覧画面にstatusを更新する「承認」「非承認」ボタンを実装
* enumを使ったselectタグの実装（enumの日本語化）

## 備考
Dealのstatusが「承認待ち」「承認済み」「引き渡し」の場合、ItemのUpdateは出来ないように
Itemモデルにdeals_in_progress?メソッドを実装しmember/item#editアクション内で条件分岐させた。

dealsコントローラのnewアクションでDealインスタンスを生成していた処理をDealモデルに移動した。
