### PR TITLE
アイテムに紐付く画像アップロード機能実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,9 @@ gem 'uglifier', '>= 1.3.0'
 gem 'devise'
 # i18n for enum
 gem 'enum_help'
+# image uploader
+gem 'carrierwave'
+gem 'mini_magick'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
       activesupport (>= 3.0.0)
       uniform_notifier (~> 1.11)
     byebug (10.0.2)
+    carrierwave (1.3.1)
+      activemodel (>= 4.0.0)
+      activesupport (>= 4.0.0)
+      mime-types (>= 1.16)
     coderay (1.1.2)
     concurrent-ruby (1.1.4)
     crass (1.0.4)
@@ -98,7 +102,11 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.3)
+    mini_magick (4.9.2)
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
@@ -227,11 +235,13 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   bullet
   byebug
+  carrierwave
   devise
   enum_help
   factory_bot_rails
   html2slim
   listen (>= 3.0.5, < 3.2)
+  mini_magick
   pg (>= 0.18, < 2.0)
   pry-rails
   puma (~> 3.11)

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -14,7 +14,7 @@ class Member::ItemsController < Member::ApplicationController
   # GET /items/new
   def new
     @item = Item.new
-    3.times { @item.item_images.build }
+    set_images
   end
 
   # GET /items/1/edit
@@ -62,8 +62,12 @@ class Member::ItemsController < Member::ApplicationController
         :price,
         :available,
         category_ids: [],
-        item_images_attributes: [:image, :_destroy, :id]
+        item_images_attributes: [:image, :image_cache, :_destroy, :id]
       )
+    end
+
+    def set_images
+      3.times { @item.item_images.build }
     end
 
     def check_progress_deals

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -14,6 +14,7 @@ class Member::ItemsController < Member::ApplicationController
   # GET /items/new
   def new
     @item = Item.new
+    3.times { @item.item_images.build }
   end
 
   # GET /items/1/edit
@@ -54,7 +55,15 @@ class Member::ItemsController < Member::ApplicationController
 
     # Only allow a trusted parameter "white list" through.
     def item_params
-      params.require(:item).permit(:name, :description, :condition, :price, :available, category_ids: [])
+      params.require(:item).permit(
+        :name,
+        :description,
+        :condition,
+        :price,
+        :available,
+        category_ids: [],
+        item_images_attributes: [:image, :_destroy, :id]
+      )
     end
 
     def check_progress_deals

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -3,6 +3,8 @@ class Item < ApplicationRecord
   has_many :deals
   has_many :item_categories, dependent: :destroy
   has_many :categories, through: :item_categories
+  has_many :item_images, dependent: :destroy
+  accepts_nested_attributes_for :item_images
 
   validates :name, presence: true
   validates :price, presence: true

--- a/app/models/item_image.rb
+++ b/app/models/item_image.rb
@@ -1,0 +1,4 @@
+class ItemImage < ApplicationRecord
+  belongs_to :item
+  mount_uploader :image, ItemImagesUploader
+end

--- a/app/uploaders/item_images_uploader.rb
+++ b/app/uploaders/item_images_uploader.rb
@@ -1,0 +1,50 @@
+class ItemImagesUploader < CarrierWave::Uploader::Base
+  include CarrierWave::MiniMagick
+  # Include RMagick or MiniMagick support:
+  # include CarrierWave::RMagick
+  # include CarrierWave::MiniMagick
+
+  # Choose what kind of storage to use for this uploader:
+  storage :file
+  # storage :fog
+
+  process :resize_to_limit => [200, 300]
+
+  # Override the directory where uploaded files will be stored.
+  # This is a sensible default for uploaders that are meant to be mounted:
+  def store_dir
+    "uploads/#{model.class.to_s.underscore}/#{mounted_as}/#{model.id}"
+  end
+
+  # Provide a default URL as a default if there hasn't been a file uploaded:
+  # def default_url(*args)
+  #   # For Rails 3.1+ asset pipeline compatibility:
+  #   # ActionController::Base.helpers.asset_path("fallback/" + [version_name, "default.png"].compact.join('_'))
+  #
+  #   "/images/fallback/" + [version_name, "default.png"].compact.join('_')
+  # end
+
+  # Process files as they are uploaded:
+  # process scale: [200, 300]
+  #
+  # def scale(width, height)
+  #   # do something
+  # end
+
+  # Create different versions of your uploaded files:
+  # version :thumb do
+  #   process resize_to_fit: [50, 50]
+  # end
+
+  # Add a white list of extensions which are allowed to be uploaded.
+  # For images you might use something like this:
+  # def extension_whitelist
+  #   %w(jpg jpeg gif png)
+  # end
+
+  # Override the filename of the uploaded files:
+  # Avoid using model.id or version_name here, see uploader/store.rb for details.
+  # def filename
+  #   "something.jpg" if original_filename
+  # end
+end

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -12,6 +12,11 @@
     = form.label :name
     = form.text_field :name
   .field
+    = form.fields_for :item_images do |item_image|
+      = image_tag(item_image.object.image.url) if item_image.object.image.url
+      = item_image.file_field :image
+      = item_image.hidden_field :id, value: item_image.object.id
+  .field
     = form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |b|
       = b.label { b.check_box + b.text }
   .field

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -15,6 +15,7 @@
     = form.fields_for :item_images do |item_image|
       = image_tag(item_image.object.image.url) if item_image.object.image.url
       = item_image.file_field :image
+      = item_image.hidden_field :image_cache
       = item_image.hidden_field :id, value: item_image.object.id
   .field
     = form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |b|

--- a/app/views/member/items/show.html.slim
+++ b/app/views/member/items/show.html.slim
@@ -8,6 +8,11 @@ p
   = @item.name
 p
   strong
+  - @item.item_images.each do |item_image|
+    |  
+    = image_tag item_image.image.url if item_image.image.url
+p
+  strong
     | Category:
   - @item.categories.each do |category|
     |  •

--- a/db/migrate/20190204130650_create_item_images.rb
+++ b/db/migrate/20190204130650_create_item_images.rb
@@ -1,0 +1,10 @@
+class CreateItemImages < ActiveRecord::Migration[5.2]
+  def change
+    create_table :item_images do |t|
+      t.references :item, foreign_key: true
+      t.string :image
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_01_26_053113) do
+ActiveRecord::Schema.define(version: 2019_02_04_130650) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -43,6 +43,14 @@ ActiveRecord::Schema.define(version: 2019_01_26_053113) do
     t.index ["item_id"], name: "index_item_categories_on_item_id"
   end
 
+  create_table "item_images", force: :cascade do |t|
+    t.bigint "item_id"
+    t.string "image"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_item_images_on_item_id"
+  end
+
   create_table "items", force: :cascade do |t|
     t.bigint "user_id"
     t.string "name", null: false
@@ -73,5 +81,6 @@ ActiveRecord::Schema.define(version: 2019_01_26_053113) do
   add_foreign_key "deals", "users", column: "lender_id"
   add_foreign_key "item_categories", "categories"
   add_foreign_key "item_categories", "items"
+  add_foreign_key "item_images", "items"
   add_foreign_key "items", "users"
 end

--- a/spec/factories/item_images.rb
+++ b/spec/factories/item_images.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :item_image do
+    item { nil }
+    image { "MyString" }
+  end
+end

--- a/spec/models/item_image_spec.rb
+++ b/spec/models/item_image_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe ItemImage, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
## 概要
* carrierwave(gem)でItemに紐づく画像アップロード機能を実装
* ひとつのアイテムにつき複数の画像をアップロードできる（暫定で最大3枚にしている）

## 備考
* temと1対多の関係になるitem_imagesテーブルを作成
* アップロードはItemのnew/edit時に行える
* mini_magick(gem)で画像のサイズを調整できるようにした

### 参考: 
Carrierwaveで画像を複数アップロードする
https://qiita.com/sinagaki58/items/a0d59cc41c6824bb5f67

fields_forの上手な使い方
https://qiita.com/kouuuki/items/5daf2b5f34273d8457f7
