### PR TITLE
Item一覧に検索機能（アイテム名、カテゴリ）を実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,7 +4,14 @@ class ItemsController < ApplicationController
   # GET /items
   # GET /items.json
   def index
-    @items = Item.all.includes(:user, :categories)
+    @items = Item.search(
+      params[:name],
+      params[:category][:category_id]
+    ).includes(
+        :user,
+        :item_categories,
+        :categories
+      )
   end
 
   # GET /items/1

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -6,7 +6,7 @@ class ItemsController < ApplicationController
   def index
     @items = Item.all.includes(:user, :categories)
     if params[:name] || params[:category]
-      @items = Item.search(
+      @items = Item.search_by(
         params[:name],
         params[:category][:category_id]
       ).includes(

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -4,14 +4,17 @@ class ItemsController < ApplicationController
   # GET /items
   # GET /items.json
   def index
-    @items = Item.search(
-      params[:name],
-      params[:category][:category_id]
-    ).includes(
-        :user,
-        :item_categories,
-        :categories
-      )
+    @items = Item.all.includes(:user, :categories)
+    if params[:name] || params[:category]
+      @items = Item.search(
+        params[:name],
+        params[:category][:category_id]
+      ).includes(
+          :user,
+          :item_categories,
+          :categories
+        )
+    end
   end
 
   # GET /items/1

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,13 +17,11 @@ class Item < ApplicationRecord
   validates :available, null: false, inclusion: { in: [true, false] }
 
   scope :get_by_name, ->(name) {
-    return all if name.blank?
-    where("items.name like ?", "#{name}%")
+    where("items.name like ?", "#{name}%") if name.present?
   }
 
   scope :get_by_category, ->(category_id) {
-    return all if category_id.blank?
-    joins(:categories).where(categories: {id: category_id})
+    joins(:categories).where(categories: {id: category_id}) if category_id.present?
   }
 
   def owner?(current_user)
@@ -34,7 +32,7 @@ class Item < ApplicationRecord
     deals.progress.present?
   end
 
-  def self.search(name, category_id)
+  def self.search_by(name, category_id)
     get_by_name(name).get_by_category(category_id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,11 +16,25 @@ class Item < ApplicationRecord
     }
   validates :available, null: false, inclusion: { in: [true, false] }
 
+  scope :get_by_name, ->(name) {
+    return all if name.blank?
+    where("items.name like ?", "#{name}%")
+  }
+
+  scope :get_by_category, ->(category_id) {
+    return all if category_id.blank?
+    joins(:categories).where(categories: {id: category_id})
+  }
+
   def owner?(current_user)
     user_id == current_user.id
   end
 
   def exist_progress_deals?
     deals.progress.present?
+  end
+
+  def self.search(name, category_id)
+    get_by_name(name).get_by_category(category_id)
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -32,7 +32,7 @@ class Item < ApplicationRecord
     deals.progress.present?
   end
 
-  def self.search_by(name, category_id)
+  def self.search_by(name=nil, category_id=nil)
     get_by_name(name).get_by_category(category_id)
   end
 end

--- a/app/views/items/index.html.slim
+++ b/app/views/items/index.html.slim
@@ -1,5 +1,16 @@
 h1
   | Items
+
+= form_tag items_path, method: 'get' do
+  .field
+    = label_tag :name, 'アイテム名'
+    = text_field_tag :name
+  .field
+    = label_tag :category, 'カテゴリ'
+    = collection_select(:category, :category_id, Category.all, :id, :name, include_blank: '指定なし')
+  .actions
+    = submit_tag '検索', name: nil
+
 table
   thead
     tr

--- a/spec/factories/categories.rb
+++ b/spec/factories/categories.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :category do
+    sequence(:name) { |n| "CATEGORY_NAME#{n}"}
+  end
+end

--- a/spec/models/item_image_spec.rb
+++ b/spec/models/item_image_spec.rb
@@ -1,5 +1,5 @@
 require 'rails_helper'
 
 RSpec.describe ItemImage, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  # pending "add some examples to (or delete) #{__FILE__}"
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -43,4 +43,62 @@ RSpec.describe Item, type: :model do
       end
     end
   end
+
+  describe 'self.search(name, category_id)' do
+    let(:category1){ create(:category, name: 'カテゴリ1')}
+    let(:category2){ create(:category, name: 'カテゴリ2')}
+    let!(:item1){ create(:item, name: 'アイテムA', categories: [category1]) }
+    let!(:item2){ create(:item, name: 'アイテムA', categories: [category2]) }
+    let!(:item3){ create(:item, name: 'アイテムB', categories: [category1]) }
+    let!(:item4){ create(:item, name: 'ITEM', categories: [category2]) }
+
+    context '名前を空欄、カテゴリ「指定なし」で検索した場合' do
+      it 'self.searchの戻り値が4個、かつitem1,item2,item3,item4が含まれること' do
+        expect(Item.search('', '').count).to eq 4
+        expect(Item.search('', '')).to include(item1, item2, item3, item4)
+      end
+    end
+
+    context '名前「アイテムA」、カテゴリ「カテゴリ1」で検索した場合' do
+      it 'self.searchの戻り値が1個、かつitem1が含まれること' do
+        expect(Item.search('アイテムA', category1.id).count).to eq 1
+        expect(Item.search('アイテムA', category1.id)).to include(item1)
+      end
+    end
+
+    context '名前「アイテムA」、カテゴリ「指定なし」で検索した場合' do
+      it 'self.searchの戻り値が2個、かつitem1,item2が含まれること' do
+        expect(Item.search('アイテムA', '').count).to eq 2
+        expect(Item.search('アイテムA', '')).to include(item1, item2)
+      end
+    end
+
+    context '名前を空欄、カテゴリ「カテゴリ1」で検索した場合' do
+      it 'self.searchの戻り値が2個、かつitem1,item3が含まれること' do
+        expect(Item.search('', category1.id).count).to eq 2
+        expect(Item.search('', category1.id)).to include(item1, item3)
+      end
+    end
+
+    context '名前「アイテム」、カテゴリ「指定なし」で検索した場合' do
+      it 'self.searchの戻り値が3個、かつitem1,item2,item3が含まれること' do
+        expect(Item.search('アイテム', '').count).to eq 3
+        expect(Item.search('アイテム', '')).to include(item1, item2, item3)
+      end
+    end
+
+    context '名前「A」、カテゴリ「指定なし」で検索した場合' do
+      it 'self.searchの戻り値が0個であること' do
+        expect(Item.search('A', '').count).to eq 0
+        expect(Item.search('A', '')).to eq []
+      end
+    end
+
+    context '存在しない名前「アイテムC」、カテゴリ「指定なし」で検索した場合' do
+      it 'self.searchの戻り値が0個であること' do
+        expect(Item.search('アイテムC', '').count).to eq 0
+        expect(Item.search('アイテムC', '')).to eq []
+      end
+    end
+  end
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Item, type: :model do
       end
 
       it 'self.search_byの戻り値が1つであること' do
-        expect(Item.search_by('', '').count).to eq 1
+        expect(Item.search_by.count).to eq 1
       end
     end
 

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -53,51 +53,62 @@ RSpec.describe Item, type: :model do
     let!(:item4){ create(:item, name: 'ITEM', categories: [category2]) }
 
     context '名前を空欄、カテゴリ「指定なし」で検索した場合' do
-      it 'self.searchの戻り値が4個、かつitem1,item2,item3,item4が含まれること' do
-        expect(Item.search('', '').count).to eq 4
-        expect(Item.search('', '')).to include(item1, item2, item3, item4)
+      let(:search_item_without_name_and_category){ Item.search('', '') }
+
+      it 'self.searchの戻り値にitem1,item2,item3,item4が全て含まれること' do
+        expect(search_item_without_name_and_category).to include(item1, item2, item3, item4)
       end
     end
 
     context '名前「アイテムA」、カテゴリ「カテゴリ1」で検索した場合' do
-      it 'self.searchの戻り値が1個、かつitem1が含まれること' do
-        expect(Item.search('アイテムA', category1.id).count).to eq 1
-        expect(Item.search('アイテムA', category1.id)).to include(item1)
+      let(:search_item_with_name_and_category){ Item.search('アイテムA', category1.id) }
+
+      it 'self.searchの戻り値にitem1のみが含まれること' do
+        expect(search_item_with_name_and_category).to include(item1)
+        expect(search_item_with_name_and_category).not_to include(item2, item3, item4)
       end
     end
 
     context '名前「アイテムA」、カテゴリ「指定なし」で検索した場合' do
-      it 'self.searchの戻り値が2個、かつitem1,item2が含まれること' do
-        expect(Item.search('アイテムA', '').count).to eq 2
-        expect(Item.search('アイテムA', '')).to include(item1, item2)
+      let(:search_item_without_category){ Item.search('アイテムA', '') }
+
+      it 'self.searchの戻り値にitem1,item2のみが含まれること' do
+        expect(search_item_without_category).to include(item1, item2)
+        expect(search_item_without_category).not_to include(item3, item4)
       end
     end
 
     context '名前を空欄、カテゴリ「カテゴリ1」で検索した場合' do
-      it 'self.searchの戻り値が2個、かつitem1,item3が含まれること' do
-        expect(Item.search('', category1.id).count).to eq 2
-        expect(Item.search('', category1.id)).to include(item1, item3)
+      let(:search_item_without_name){ Item.search('', category1.id) }
+
+      it 'self.searchの戻り値にitem1,item3のみが含まれること' do
+        expect(search_item_without_name).to include(item1, item3)
+        expect(search_item_without_name).not_to include(item2, item4)
       end
     end
 
     context '名前「アイテム」、カテゴリ「指定なし」で検索した場合' do
-      it 'self.searchの戻り値が3個、かつitem1,item2,item3が含まれること' do
-        expect(Item.search('アイテム', '').count).to eq 3
-        expect(Item.search('アイテム', '')).to include(item1, item2, item3)
+      let(:search_item_with_name_kana){ Item.search('アイテム', '') }
+
+      it 'self.searchの戻り値にitem1,item2,item3のみが含まれること' do
+        expect(search_item_with_name_kana).to include(item1, item2, item3)
+        expect(search_item_with_name_kana).not_to include(item4)
       end
     end
 
     context '名前「A」、カテゴリ「指定なし」で検索した場合' do
-      it 'self.searchの戻り値が0個であること' do
-        expect(Item.search('A', '').count).to eq 0
-        expect(Item.search('A', '')).to eq []
+      let(:search_item_with_name_a){ Item.search('A', '') }
+
+      it 'self.searchの戻り値が空であること' do
+        expect(search_item_with_name_a).not_to include [item1, item2, item3, item4]
       end
     end
 
     context '存在しない名前「アイテムC」、カテゴリ「指定なし」で検索した場合' do
-      it 'self.searchの戻り値が0個であること' do
-        expect(Item.search('アイテムC', '').count).to eq 0
-        expect(Item.search('アイテムC', '')).to eq []
+      let(:search_item_with_name_c){ Item.search('アイテムC', '') }
+
+      it 'self.searchの戻り値が空であること' do
+        expect(search_item_with_name_c).not_to include [item1, item2, item3, item4]
       end
     end
   end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -44,71 +44,55 @@ RSpec.describe Item, type: :model do
     end
   end
 
-  describe 'self.search(name, category_id)' do
+  describe 'self.search_by' do
     let(:category1){ create(:category, name: 'カテゴリ1')}
     let(:category2){ create(:category, name: 'カテゴリ2')}
-    let!(:item1){ create(:item, name: 'アイテムA', categories: [category1]) }
-    let!(:item2){ create(:item, name: 'アイテムA', categories: [category2]) }
-    let!(:item3){ create(:item, name: 'アイテムB', categories: [category1]) }
-    let!(:item4){ create(:item, name: 'ITEM', categories: [category2]) }
 
-    context '名前を空欄、カテゴリ「指定なし」で検索した場合' do
-      let(:search_item_without_name_and_category){ Item.search('', '') }
+    context '検索条件が存在しない場合' do
+      before do
+        create(:item)
+      end
 
-      it 'self.searchの戻り値にitem1,item2,item3,item4が全て含まれること' do
-        expect(search_item_without_name_and_category).to include(item1, item2, item3, item4)
+      it 'self.search_byの戻り値が1つであること' do
+        expect(Item.search_by('', '').count).to eq 1
       end
     end
 
-    context '名前「アイテムA」、カテゴリ「カテゴリ1」で検索した場合' do
-      let(:search_item_with_name_and_category){ Item.search('アイテムA', category1.id) }
+    context '検索条件が存在する場合' do
+      context 'name検索' do
+        before do
+          create(:item, name: 'アイテム1')
+          create(:item, name: 'アイテム')
+          create(:item, name: 'ITEM')
+        end
 
-      it 'self.searchの戻り値にitem1のみが含まれること' do
-        expect(search_item_with_name_and_category).to include(item1)
-        expect(search_item_with_name_and_category).not_to include(item2, item3, item4)
+        it 'self.search_byの戻り値が2つであること' do
+          expect(Item.search_by('アイテム', '').count).to eq 2
+        end
       end
-    end
 
-    context '名前「アイテムA」、カテゴリ「指定なし」で検索した場合' do
-      let(:search_item_without_category){ Item.search('アイテムA', '') }
+      context 'category検索' do
+        before do
+          create(:item, categories: [category1])
+          create(:item, categories: [category2])
+        end
 
-      it 'self.searchの戻り値にitem1,item2のみが含まれること' do
-        expect(search_item_without_category).to include(item1, item2)
-        expect(search_item_without_category).not_to include(item3, item4)
+        it 'self.search_byの戻り値が1つであること' do
+          expect(Item.search_by('', category1.id).count).to eq 1
+        end
       end
-    end
 
-    context '名前を空欄、カテゴリ「カテゴリ1」で検索した場合' do
-      let(:search_item_without_name){ Item.search('', category1.id) }
+      context '複合検索' do
+        before do
+          create(:item, name: 'アイテム1', categories: [category1])
+          create(:item, name: 'アイテム1', categories: [category2])
+          create(:item, name: 'アイテム2', categories: [category1])
+          create(:item, name: 'アイテム2', categories: [category2])
+        end
 
-      it 'self.searchの戻り値にitem1,item3のみが含まれること' do
-        expect(search_item_without_name).to include(item1, item3)
-        expect(search_item_without_name).not_to include(item2, item4)
-      end
-    end
-
-    context '名前「アイテム」、カテゴリ「指定なし」で検索した場合' do
-      let(:search_item_with_name_kana){ Item.search('アイテム', '') }
-
-      it 'self.searchの戻り値にitem1,item2,item3のみが含まれること' do
-        expect(search_item_with_name_kana).to include(item1, item2, item3)
-        expect(search_item_with_name_kana).not_to include(item4)
-      end
-    end
-
-    context '名前「A」、カテゴリ「指定なし」で検索した場合' do
-      let(:search_item_with_name_a){ Item.search('A', '') }
-
-      it 'self.searchの戻り値が空であること' do
-        expect(search_item_with_name_a).not_to include [item1, item2, item3, item4]
-      end
-    end
-
-    context '存在しない名前「アイテムC」、カテゴリ「指定なし」で検索した場合' do
-      let(:search_item_with_name_c){ Item.search('アイテムC', '') }
-
-      it 'self.searchの戻り値が空であること' do
-        expect(search_item_with_name_c).not_to include [item1, item2, item3, item4]
+        it 'self.search_byの戻り値が1つであること' do
+          expect(Item.search_by('アイテム1', category1.id).count).to eq 1
+        end
       end
     end
   end


### PR DESCRIPTION
## 何を実現するためのPRか？
アイテム一覧画面でアイテムの絞り込みができるように検索機能を設置

### 外部URL
#26

## 実装内容
<!-- ここには具体的にどのような実装をしたかを書く -->

* 検索ボックスの項目はアイテム名(テキストフィールド)とカテゴリ(セレクトボックス)
* itemモデルにself.searchメソッドを追加し、items#indexから呼び出すようにした
* 名前検索は前方一致で絞り込み
* self.searchメソッドのテストコードを実装

参考URL:
https://qiita.com/yusuko/items/cff4e46aeafbc3beecf2
https://blog.codecamp.jp/rails_text_21

## 考えられる影響範囲
<!-- ここには今回の主目的以外に影響がありそうな箇所を実装者目線で書き出す -->

特になし

## 実装者目線で特に重点的にレビューしてほしい所
<!-- 影響範囲広そうなロジックの箇所や、自分でも確認が大変だった箇所等を記載する -->

* self.searchメソッドの引数が空の場合の処理の書き方

## UIの変更
<!-- UIの変更があれば、変更前、変更後のスクリーンショットを貼る -->

|変更前 | 変更後|
|-|-|
|![baki](https://user-images.githubusercontent.com/38211088/52548256-e9002a00-2e0f-11e9-8add-963d8c45dc16.png)|![idea_gou_01](https://user-images.githubusercontent.com/38211088/52548281-1b118c00-2e10-11e9-8046-d907ac204d80.png)|


## レビュー期限
なし

## 動作確認リスト
<!-- この実装にあたって、動作を担保するために自身が行ったクライアント側（主にブラウザ）の操作を書く。レビュアーはこの動作確認リストもレビューして不足が無いかチェックする -->

- [ ] `/items` にアクセスしてItem検索フォームがが設置されていることを確認

- [ ] `検索フォームにアイテム名を入力orカテゴリを選択し検索ボタンを押すと、入力データに応じたアイテムに絞られて表示されることを確認