### PR TITLE
kaminariでページネーションを追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,8 @@ gem 'enum_help'
 # image uploader
 gem 'carrierwave'
 gem 'mini_magick'
+# pagination
+gem 'kaminari'
 
 # Use Redis adapter to run Action Cable in production
 # gem 'redis', '~> 4.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,18 @@ GEM
       hpricot
     i18n (1.5.1)
       concurrent-ruby (~> 1.0)
+    kaminari (1.1.1)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.1.1)
+      kaminari-activerecord (= 1.1.1)
+      kaminari-core (= 1.1.1)
+    kaminari-actionview (1.1.1)
+      actionview
+      kaminari-core (= 1.1.1)
+    kaminari-activerecord (1.1.1)
+      activerecord
+      kaminari-core (= 1.1.1)
+    kaminari-core (1.1.1)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -240,6 +252,7 @@ DEPENDENCIES
   enum_help
   factory_bot_rails
   html2slim
+  kaminari
   listen (>= 3.0.5, < 3.2)
   mini_magick
   pg (>= 0.18, < 2.0)

--- a/app/controllers/member/deals_controller.rb
+++ b/app/controllers/member/deals_controller.rb
@@ -6,8 +6,21 @@ class Member::DealsController < Member::ApplicationController
 
   # GET /deals
   def index
-    @lender_deals = Deal.where(lender_id: current_user.id).includes(:item, :lender, :borrower)
-    @borrower_deals = Deal.where(borrower_id: current_user.id).includes(:item, :lender, :borrower)
+    @lender_deals = Deal.where(
+      lender_id: current_user.id
+    ).includes(
+      :item, :lender, :borrower
+    ).order(
+      created_at: "DESC"
+    ).page params[:lender_page]
+
+    @borrower_deals = Deal.where(
+      borrower_id: current_user.id
+    ).includes(
+      :item, :lender, :borrower
+    ).order(
+      created_at: "DESC"
+    ).page params[:borrower_page]
   end
 
   # GET /deals/1

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -4,7 +4,7 @@ class Member::ItemsController < Member::ApplicationController
 
   # GET /items
   def index
-    @items = current_user.items.includes(:categories)
+    @items = current_user.items.includes(:categories).order(created_at: "DESC").page params[:page]
   end
 
   # GET /items/1

--- a/app/views/member/deals/index.html.slim
+++ b/app/views/member/deals/index.html.slim
@@ -27,6 +27,8 @@ table
         td = button_to '承認', member_deal_path(lender_deal, params: { deal: { status: 'approved'} }), method: :patch
         td = button_to '非承認', member_deal_path(lender_deal, params: { deal: { status: 'rejected'} }), method: :patch
 
+= paginate @lender_deals, param_name: :lender_page
+
 h2 borrower_deals
 table
   thead
@@ -52,3 +54,5 @@ table
         td = link_to 'Edit', edit_member_deal_path(borrower_deal)
         td = link_to 'Destroy', member_deal_path(borrower_deal),
           data: { confirm: 'Are you sure?' }, method: :delete
+
+= paginate @borrower_deals, param_name: :borrower_page

--- a/app/views/member/items/index.html.slim
+++ b/app/views/member/items/index.html.slim
@@ -43,5 +43,6 @@ table
           = link_to 'Edit', edit_member_item_path(item)
         td
           = link_to 'Destroy', [:member, item], method: :delete, data: { confirm: 'Are you sure?' }
+= paginate @items
 br
 = link_to 'New Item', new_member_item_path

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+Kaminari.configure do |config|
+  config.default_per_page = 10
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.params_on_first_page = false
+end


### PR DESCRIPTION
## 何を実現するためのPRか？
member直下のItemとDealのViewにページネーション追加

### 外部URL
#27

## 実装内容
<!-- ここには具体的にどのような実装をしたかを書く -->

* kaminariでページネーションを実装 (対象はmember直下のItemとDeal)
* kaminari_config.rbで1ページの最大表示件数のデフォルト値を10件にした
* deals/indexのviewではlenderとborrowerで2種類のDeals一覧が存在するため、ページネーション時に持たせるparamsをそれぞれ `:lender_page`, `:borrower_page` に分けて実装した

## 考えられる影響範囲
<!-- ここには今回の主目的以外に影響がありそうな箇所を実装者目線で書き出す -->

特になし

## UIの変更
<!-- UIの変更があれば、変更前、変更後のスクリーンショットを貼る -->

|変更前 | 変更後|
|-|-|
|![baki](https://user-images.githubusercontent.com/38211088/52722070-43ef7800-2fee-11e9-9bed-b7e7ed81f1c7.png)|![idea_gou_01](https://user-images.githubusercontent.com/38211088/52722384-ce37dc00-2fee-11e9-9ae2-f569925c2a98.png)|

## 動作確認リスト
<!-- この実装にあたって、動作を担保するために自身が行ったクライアント側（主にブラウザ）の操作を書く。レビュアーはこの動作確認リストもレビューして不足が無いかチェックする -->

- [ ] `/member/items` および `/member/items/:id/delas` にアクセスしてItemとDealがそれぞれ10件表示されているのを確認

- [ ] `Next` や `Previous` を押下するとページが切り替わることを確認