### PR TITLE
非承認もしくは中断(stutsがrejected or cancelled)のDealを一括削除する機能追加

### DIFF
--- a/app/controllers/member/deals_controller.rb
+++ b/app/controllers/member/deals_controller.rb
@@ -48,8 +48,8 @@ class Member::DealsController < Member::ApplicationController
     end
   end
 
-  def destroy_all
-    if Deal.destroy_all_closed_deals(current_user)
+  def destroys
+    if Deal.destroy_closed_deals(current_user)
       redirect_to member_deals_path, notice: '終了した取引を全て削除しました。'
     else
       redirect_to member_deals_psth, notice: '一括削除に失敗しました。'

--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -71,6 +71,6 @@ class Member::ItemsController < Member::ApplicationController
     end
 
     def check_progress_deals
-      redirect_to member_item_deals_path(@item), notice: ' 進行中の取引があります。' if @item.exist_progress_deals?
+      redirect_to member_deals_path, notice: ' 進行中の取引があります。' if @item.exist_progress_deals?
     end
 end

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -12,6 +12,9 @@ class Deal < ApplicationRecord
   validates :status, inclusion: { in: Deal.statuses.keys }
 
   scope :progress, -> { where(status: 0..2) }
+  scope :not_outdated, -> { where(status: 0..3) }
+  scope :outdated, -> { where(status: 4..5) }
+  scope :not_deleted, -> { where(deleted_at: nil) }
 
   def borrower?(current_user)
     borrower_id == current_user.id

--- a/app/models/deal.rb
+++ b/app/models/deal.rb
@@ -37,8 +37,8 @@ class Deal < ApplicationRecord
     borrower_id == current_user.id
   end
 
-  def self.destroy_all_closed_deals(current_user)
-    deals = current_user.lending_deals.closed
+  def self.destroy_closed_deals(user)
+    deals = user.lending_deals.closed
     Deal.transaction do
       deals.each do |deal|
         deal.deleted_at = Time.now

--- a/app/views/member/deals/edit.html.slim
+++ b/app/views/member/deals/edit.html.slim
@@ -4,4 +4,4 @@ h1 Editing deal
 
 = link_to 'Show', member_deal_path(@deal)
 | |
-= link_to 'Back', member_item_deals_path(@deal.item)
+= link_to 'Back', member_deals_path

--- a/app/views/member/deals/index.html.slim
+++ b/app/views/member/deals/index.html.slim
@@ -25,15 +25,15 @@ table
         td = lender_deal.status_i18n
         td = link_to 'Show', member_deal_path(lender_deal)
         td = link_to 'Edit', edit_member_deal_path(lender_deal)
-        - if lender_deal.status == 'submitted'
+        - if lender_deal.submitted?
           td = button_to '承認', member_deal_path(lender_deal, params: { deal: { status: 'approved'} }), method: :patch
           td = button_to '非承認', member_deal_path(lender_deal, params: { deal: { status: 'rejected'} }), method: :patch
 
-= paginate @lender_deals, param_name: :lender_page
+= paginate @lender_deals, param_name: :lender_deals_page
 
-- if @outdated_deals.exists?
-  h3 outdated_deals
-  = button_to '一括削除', member_deal_path(current_user.items.first), method: :delete
+- if @closed_deals.present?
+  h3 closed_deals
+  = button_to '一括削除', destroy_all_member_deals_path, method: :delete
   table
     thead
       tr
@@ -46,17 +46,17 @@ table
         th
 
     tbody
-      - @outdated_deals.each do |outdated_deal|
+      - @closed_deals.each do |closed_deal|
         tr
-          td = outdated_deal.item.name
-          td = outdated_deal.lender.name
-          td = outdated_deal.borrower.name
-          td = outdated_deal.unit_price
-          td = outdated_deal.status_i18n
-          td = link_to 'Show', member_deal_path(outdated_deal)
-          td = link_to 'Edit', edit_member_deal_path(outdated_deal)
+          td = closed_deal.item.name
+          td = closed_deal.lender.name
+          td = closed_deal.borrower.name
+          td = closed_deal.unit_price
+          td = closed_deal.status_i18n
+          td = link_to 'Show', member_deal_path(closed_deal)
+          td = link_to 'Edit', edit_member_deal_path(closed_deal)
 
-= paginate @outdated_deals, param_name: :outdated_page
+= paginate @closed_deals, param_name: :closed_deals_page
 
 h2 borrower_deals
 table
@@ -84,4 +84,4 @@ table
         td = link_to 'Destroy', member_deal_path(borrower_deal),
           data: { confirm: 'Are you sure?' }, method: :delete
 
-= paginate @borrower_deals, param_name: :borrower_page
+= paginate @borrower_deals, param_name: :borrower_deals_page

--- a/app/views/member/deals/index.html.slim
+++ b/app/views/member/deals/index.html.slim
@@ -13,6 +13,7 @@ table
       th
       th
       th
+      th
 
   tbody
     - @lender_deals.each do |lender_deal|
@@ -24,10 +25,38 @@ table
         td = lender_deal.status_i18n
         td = link_to 'Show', member_deal_path(lender_deal)
         td = link_to 'Edit', edit_member_deal_path(lender_deal)
-        td = button_to '承認', member_deal_path(lender_deal, params: { deal: { status: 'approved'} }), method: :patch
-        td = button_to '非承認', member_deal_path(lender_deal, params: { deal: { status: 'rejected'} }), method: :patch
+        - if lender_deal.status == 'submitted'
+          td = button_to '承認', member_deal_path(lender_deal, params: { deal: { status: 'approved'} }), method: :patch
+          td = button_to '非承認', member_deal_path(lender_deal, params: { deal: { status: 'rejected'} }), method: :patch
 
 = paginate @lender_deals, param_name: :lender_page
+
+- if @outdated_deals.exists?
+  h3 outdated_deals
+  = button_to '一括削除', member_deal_path(current_user.items.first), method: :delete
+  table
+    thead
+      tr
+        th Item
+        th Lender
+        th Borrower
+        th Unit price
+        th Status
+        th
+        th
+
+    tbody
+      - @outdated_deals.each do |outdated_deal|
+        tr
+          td = outdated_deal.item.name
+          td = outdated_deal.lender.name
+          td = outdated_deal.borrower.name
+          td = outdated_deal.unit_price
+          td = outdated_deal.status_i18n
+          td = link_to 'Show', member_deal_path(outdated_deal)
+          td = link_to 'Edit', edit_member_deal_path(outdated_deal)
+
+= paginate @outdated_deals, param_name: :outdated_page
 
 h2 borrower_deals
 table

--- a/app/views/member/deals/index.html.slim
+++ b/app/views/member/deals/index.html.slim
@@ -33,7 +33,7 @@ table
 
 - if @closed_deals.present?
   h3 closed_deals
-  = button_to '一括削除', destroy_all_member_deals_path, method: :delete
+  = button_to '一括削除', destroys_member_deals_path, method: :delete
   table
     thead
       tr

--- a/app/views/member/deals/new.html.slim
+++ b/app/views/member/deals/new.html.slim
@@ -2,4 +2,4 @@ h1 New deal
 
 = render 'form',  deal: @deal
 
-= link_to 'Back', member_item_deals_path
+= link_to 'Back', member_deals_path

--- a/app/views/member/deals/show.html.slim
+++ b/app/views/member/deals/show.html.slim
@@ -16,4 +16,4 @@ p
 
 => link_to 'Edit', edit_member_deal_path(@deal)
 '|
-=< link_to 'Back', member_item_deals_path(@deal.item)
+=< link_to 'Back', member_deals_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,7 +9,13 @@ Rails.application.routes.draw do
   namespace :member do
     resources :users, only: %i[show edit update]
     resources :items, shallow: true do
-      resources :deals
+      resources :deals, only: %i[new create]
+    end
+
+    resources :deals do
+      collection do
+        delete :destroy_all
+      end
     end
   end
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,7 +14,7 @@ Rails.application.routes.draw do
 
     resources :deals do
       collection do
-        delete :destroy_all
+        delete :destroys
       end
     end
   end

--- a/db/migrate/20190215140733_add_deleted_at_to_deals.rb
+++ b/db/migrate/20190215140733_add_deleted_at_to_deals.rb
@@ -1,0 +1,5 @@
+class AddDeletedAtToDeals < ActiveRecord::Migration[5.2]
+  def change
+    add_column :deals, :deleted_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_04_130650) do
+ActiveRecord::Schema.define(version: 2019_02_15_140733) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2019_02_04_130650) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "status", default: 0, null: false
+    t.datetime "deleted_at"
     t.index ["borrower_id"], name: "index_deals_on_borrower_id"
     t.index ["item_id"], name: "index_deals_on_item_id"
     t.index ["lender_id"], name: "index_deals_on_lender_id"

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe Deal, type: :model do
+  describe 'self.destroy_all_closed_deals' do
+    let(:user){ create(:user) }
+    let(:item){ create(:item, user: user) }
+
+    context 'openな取引が2つ、closedな取引が2つ存在する場合' do
+      before do
+        create(:deal, item: item, status: :submitted, deleted_at: nil)
+        create(:deal, item: item, status: :return, deleted_at: nil)
+        create(:deal, item: item, status: :rejected, deleted_at: nil)
+        create(:deal, item: item, status: :cancelled, deleted_at: nil)
+      end
+      it 'self.destroy_all_closed_dealsの実行後、deleted_atがnilでない取引が2つ存在すること' do
+        Deal.destroy_all_closed_deals(user)
+        expect(user.lending_deals.where.not(deleted_at: nil).count).to eq 2
+      end
+    end
+  end
+end

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -1,21 +1,27 @@
 require 'rails_helper'
 
 RSpec.describe Deal, type: :model do
-  describe 'self.destroy_all_closed_deals' do
+  describe 'self.destroy_closed_deals' do
     let(:user){ create(:user) }
     let(:item){ create(:item, user: user) }
 
-    context 'openな取引が2つ、closedな取引が2つ存在する場合' do
-      before do
-        create(:deal, item: item, status: :submitted, deleted_at: nil)
-        create(:deal, item: item, status: :return, deleted_at: nil)
-        create(:deal, item: item, status: :rejected, deleted_at: nil)
-        create(:deal, item: item, status: :cancelled, deleted_at: nil)
-      end
-      it 'self.destroy_all_closed_dealsの実行後、deleted_atがnilでない取引が2つ存在すること' do
-        Deal.destroy_all_closed_deals(user)
-        expect(user.lending_deals.where.not(deleted_at: nil).count).to eq 2
-      end
+    before do
+      # open状態のdeal作成
+      create(:deal, item: item, status: :submitted, deleted_at: nil)
+      create(:deal, item: item, status: :return, deleted_at: nil)
+      # closed状態のdeal作成
+      create(:deal, item: item, status: :rejected, deleted_at: nil)
+      create(:deal, item: item, status: :cancelled, deleted_at: nil)
+
+      Deal.destroy_closed_deals(user)
+    end
+
+    it 'open状態のdealが削除されていないこと' do
+      expect(user.lending_deals.open.count).to eq 2
+    end
+
+    it 'closed状態のdealが削除されていること' do
+      expect(user.lending_deals.closed.count).to eq 0
     end
   end
 end

--- a/spec/models/deal_spec.rb
+++ b/spec/models/deal_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Deal, type: :model do
       # closed状態のdeal作成
       create(:deal, item: item, status: :rejected, deleted_at: nil)
       create(:deal, item: item, status: :cancelled, deleted_at: nil)
-
+      # closed状態のdeal削除
       Deal.destroy_closed_deals(user)
     end
 


### PR DESCRIPTION
## 何を実現するためのPRか？
<!-- ここには何のためにこのPRがあるかを書く -->
承認拒否もしくは中断(stutsがrejected or cancelled)のDealを一括削除するための機能を追加

### 外部URL
<!-- ここにはgithubのissueやasana, slackのやりとりのURLをはる。 レビュアーが見た時に仕様がわかるようにするのが目的 -->

#28

## 実装内容
<!-- ここには具体的にどのような実装をしたかを書く -->

* member/DealsController#indexのビューに表題のDealを一括削除するリンクを設置
* dealsテーブルにdeleted_atカラムを追加する論理削除で実装
* Dealのクラスメソッドself.destroy_all_closed_dealsを定義し一括削除の処理をトランザクションでまとめた
  (参考URL:http://railsdoc.com/references/transaction)
* self.destroy_all_closed_dealsメソッドのテストを作成
* indexのビューで非承認もしくは中断のDealを進行中のDealと分けて表示するようにした


## 実装者目線で特に重点的にレビューしてほしい所
<!-- 影響範囲広そうなロジックの箇所や、自分でも確認が大変だった箇所等を記載する -->

メソッドをトランザクションで実装したことがないので、使い方が間違っていればご指摘お願いします。

## UIの変更
<!-- UIの変更があれば、変更前、変更後のスクリーンショットを貼る -->

|変更前 | 変更後|
|-|-|
|![baki](https://user-images.githubusercontent.com/38211088/53142173-49dcee80-35d6-11e9-859d-28e9fb1e55a2.png)|![idea_gou_01](https://user-images.githubusercontent.com/38211088/53142130-29ad2f80-35d6-11e9-9799-2b854d8afa74.png)|


## 動作確認リスト
<!-- この実装にあたって、動作を担保するために自身が行ったクライアント側（主にブラウザ）の操作を書く。レビュアーはこの動作確認リストもレビューして不足が無いかチェックする -->

- [ ] `/member/deals` にアクセスしてDeal一括削除のリンクが設置されていることを確認

- [ ] 一括削除リンクをクリックするとstutsがrejected or cancelledのDealが一括で削除されることを確認

- [ ] 一括削除が途中で失敗するとロールバックされることを確認