### PR TITLE
画像の複数削除機能を実装

### DIFF
--- a/app/controllers/member/items_controller.rb
+++ b/app/controllers/member/items_controller.rb
@@ -62,7 +62,7 @@ class Member::ItemsController < Member::ApplicationController
         :price,
         :available,
         category_ids: [],
-        item_images_attributes: [:image, :image_cache, :_destroy, :id]
+        item_images_attributes: [:image, :image_cache, :remove_image, :id]
       )
     end
 

--- a/app/views/member/items/_form.html.slim
+++ b/app/views/member/items/_form.html.slim
@@ -17,6 +17,9 @@
       = item_image.file_field :image
       = item_image.hidden_field :image_cache
       = item_image.hidden_field :id, value: item_image.object.id
+      label
+        = item_image.check_box :remove_image
+        | 削除
   .field
     = form.collection_check_boxes :category_ids, Category.all, :id, :name, include_hidden: false do |b|
       = b.label { b.check_box + b.text }


### PR DESCRIPTION
## 何を実現するためのPRか？
<!-- ここには何のためにこのPRがあるかを書く -->
画像の複数削除が行えるようにしたい

### 外部URL
<!-- ここにはgithubのissueやasana, slackのやりとりのURLをはる。 レビュアーが見た時に仕様がわかるようにするのが目的 -->

#1

## 実装内容
<!-- ここには具体的にどのような実装をしたかを書く -->

* `/mypage/edit` を新規作成し、そこで自分の情報を編集できるように修正
  * 動線は `/mypage` から設置
* 合わせて `mypage::me_controller` をリファクタ

## 考えられる影響範囲
<!-- ここには今回の主目的以外に影響がありそうな箇所を実装者目線で書き出す -->

`mypage::me_controller` をリファクタしているので `/mypage/email_change` にも影響がある

## 実装者目線で特に重点的にレビューしてほしい所
<!-- 影響範囲広そうなロジックの箇所や、自分でも確認が大変だった箇所等を記載する -->

`mypage::me_controller` をリファクタしているので `/mypage/email_change` も合わせて確認したが、それ以外にこのリファクタが影響を及ぼすところが無いか改めて見てほしい。


## UIの変更
<!-- UIの変更があれば、変更前、変更後のスクリーンショットを貼る -->

|変更前 | 変更後|
|-|-|
|![baki](https://user-images.githubusercontent.com/1719765/52314625-e4460b00-29f6-11e9-972e-9f9573612fd1.jpg)|![idea_gou_01](https://user-images.githubusercontent.com/1719765/52314633-eb6d1900-29f6-11e9-8ab1-763d8a033cf9.png)|


## レビュー期限
2019/MM/DD

## 動作確認リスト
<!-- この実装にあたって、動作を担保するために自身が行ったクライアント側（主にブラウザ）の操作を書く。レビュアーはこの動作確認リストもレビューして不足が無いかチェックする -->

- [ ] `/mypage` にアクセスして、 `/mypage/edit` への動線のリンクが設置されていることを確認

- [ ] `/mypage/edit` から自分の情報を更新すると `/mypage/profile`にリダイレクトされ更新情報が反映されていることを確認

- [ ] 既に存在する `/mypage/email_change` での動作に影響が無いことを確認